### PR TITLE
Deprecate `CommandPipe` type

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,7 +11,6 @@ Flag
 Option
 AndCommands
 OrCommands
-CommandPipe
 Redirect
 CommandRedirect
 Command

--- a/src/CommandComposer.jl
+++ b/src/CommandComposer.jl
@@ -1,7 +1,6 @@
 module CommandComposer
 
-export Flag,
-    Option, AndCommands, OrCommands, CommandPipe, Redirect, CommandRedirect, Command
+export Flag, Option, AndCommands, OrCommands, Redirect, CommandRedirect, Command
 
 abstract type CommandParameter end
 
@@ -77,16 +76,6 @@ end
 Represents a disjunction of two commands (i.e., either command is executed).
 """
 struct OrCommands <: AbstractCommand
-    a::AbstractCommand
-    b::AbstractCommand
-end
-
-"""
-    CommandPipe(a::AbstractCommand, b::AbstractCommand)
-
-Represents a pipeline of two commands (i.e., the output of the first command is used as input to the second command).
-"""
-struct CommandPipe <: AbstractCommand
     a::AbstractCommand
     b::AbstractCommand
 end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -69,27 +69,6 @@ function interpret(command::CommandRedirect)
     end
 end
 """
-    interpret(commands::CommandPipe)
-
-Translate a `CommandPipe` object into a `Cmd` that can be executed, considering the piping.
-
-# Examples
-```jldoctest
-julia> c1 = Command("ls", [], [], [], []);
-
-julia> c2 = Command("grep", [], [Option("ignore-case", "i", "ignore case", "txt")], [], []);
-
-julia> cp = CommandPipe(c1, c2);
-
-julia> cmd = interpret(cp)
-pipeline(`ls`, stdout=`grep --ignore-case=txt`)
-
-julia> typeof(cmd)
-Base.OrCmds
-```
-"""
-interpret(commands::CommandPipe) = pipeline(interpret(commands.a), interpret(commands.b))
-"""
     interpret(commands::AndCommands)
 
 Translate an `AndCommands` object into a `Base.AndCmds` that can be executed, considering the conjunction.

--- a/src/show.jl
+++ b/src/show.jl
@@ -37,13 +37,6 @@ function _show(io::IO, command::Command, indent=0)
         end
     end
 end
-function _show(io::IO, commands::CommandPipe, indent=0)
-    println(io, ' '^(indent * 2), "CommandPipe:")
-    println(io, ' '^((indent + 1) * 2), "Command 1:")
-    _show(io, commands.a, indent + 2)
-    println(io, ' '^((indent + 1) * 2), "Command 2:")
-    return _show(io, commands.b, indent + 2)
-end
 function _show(io::IO, commands::AndCommands, indent=0)
     println(io, ' '^(indent * 2), "AndCommands:")
     println(io, ' '^((indent + 1) * 2), "Command 1:")

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -80,11 +80,11 @@
         @test cmd == pipeline(interpret(git), interpret(ls))
         @test typeof(cmd) == Base.OrCmds
     end
-    @testset "Test `CommandPipe`" begin
+    @testset "Test `OrCommands`" begin
         l = Flag("long-format", "l", "use a long listing format")
         ls = Command("ls", [l], [], [], [])
         grep = Command("grep", [], [], [".bashrc"], [])
-        pipe = CommandPipe(ls, grep)
+        pipe = OrCommands(ls, grep)
         cmd = interpret(pipe)
         @test cmd == pipeline(`ls --long-format`, `grep .bashrc`)
         @test typeof(cmd) == Base.OrCmds


### PR DESCRIPTION
It is equivalent to `OrCommands`